### PR TITLE
Add ENSA Khouribga usms.ac.ma)for JetBrains License

### DIFF
--- a/lib/domains/ma/ac/usms.txt
+++ b/lib/domains/ma/ac/usms.txt
@@ -1,0 +1,2 @@
+École Nationale des Sciences Appliquées de Khouribga
+National School of Applied Sciences of Khouribga


### PR DESCRIPTION
Adding ENSA Khouribga / USMS as a recognized educational institution for JetBrains student licenses.
Links:
ENSA Khouribga: http://ensak.usms.ac.ma/ensak/
USMS: https://www.usms.ac.ma